### PR TITLE
fix: ensure image fills card container

### DIFF
--- a/src/routes/dash/index.tsx
+++ b/src/routes/dash/index.tsx
@@ -28,7 +28,7 @@ function RouteComponent() {
         <Image
           removeWrapper
           alt="Analytics dashboard background"
-          className="z-0 rounded-none object-cover"
+          className="z-0 h-full w-full rounded-none object-cover"
           src="https://images.pexels.com/photos/3030268/pexels-photo-3030268.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
         />
         <CardFooter className="absolute bottom-0 z-10 border-default-600 border-t-1 bg-black/40 dark:border-default-100">


### PR DESCRIPTION
# before
<img width="871" alt="Google Chrome 2025-03-19 21 51 40" src="https://github.com/user-attachments/assets/672f046a-dda1-48b8-9272-da8a711dd911" />

# after
larger screen:

<img width="1515" alt="image" src="https://github.com/user-attachments/assets/5f41c86d-3d56-4709-b53d-332a5d19dcf2" />

smaller screen:

<img width="850" alt="image" src="https://github.com/user-attachments/assets/52797ee3-5a6d-415c-b9c5-86f4ee418833" />
